### PR TITLE
Add missing OAuth scopes for tailnet settings

### DIFF
--- a/cmd/tailscale-exporter/root.go
+++ b/cmd/tailscale-exporter/root.go
@@ -127,6 +127,8 @@ func runExporter(cmd *cobra.Command, args []string) error {
 			"users:read",
 			"dns:read",
 			"auth_keys:read",
+			"feature_settings:read",
+			"policy_file:read",
 		}, // Request needed scopes
 	}
 


### PR DESCRIPTION
The feature_settings:read and policy_file:read scopes are required to properly retrieve tailnet settings from the API. 

Before fixing: 
```
tailscale_tailnet_settings_devices_key_duration_days{tailnet="XXX.ts.net"} 0
tailscale_tailnet_settings_info{acls_external_link="",acls_externally_managed_on="false",devices_approval_on="false",devices_auto_updates_on="false",network_flow_logging_on="false",posture_identity_collection_on="false",regional_routing_on="false",tailnet="XXX.ts.net",users_approval_on="false",users_role_allowed_to_join_external_tailnets=""} 1
```

After fix:
```
tailscale_tailnet_settings_devices_key_duration_days{tailnet="XXX.ts.net"} 6
tailscale_tailnet_settings_info{acls_external_link="https://XXX/tailscale",acls_externally_managed_on="true",devices_approval_on="false",devices_auto_updates_on="true",network_flow_logging_on="false",posture_identity_collection_on="true",regional_routing_on="true",tailnet="XXX.ts.net",users_approval_on="false",users_role_allowed_to_join_external_tailnets="admin"} 1