### PR TITLE
fix(collector): Tailscale devices routes advertised not behaving correctly

### DIFF
--- a/cmd/tailscale-exporter/root.go
+++ b/cmd/tailscale-exporter/root.go
@@ -127,6 +127,8 @@ func runExporter(cmd *cobra.Command, args []string) error {
 			"users:read",
 			"dns:read",
 			"auth_keys:read",
+			"feature_settings:read",
+			"policy_file:read",
 		}, // Request needed scopes
 	}
 

--- a/cmd/tailscale-exporter/root.go
+++ b/cmd/tailscale-exporter/root.go
@@ -124,6 +124,7 @@ func runExporter(cmd *cobra.Command, args []string) error {
 		TokenURL:     "https://api.tailscale.com/api/v2/oauth/token",
 		Scopes: []string{
 			"devices:read",
+			"devices:routes:read",
 			"users:read",
 			"dns:read",
 			"auth_keys:read",

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -59,10 +59,10 @@ func (m *MockDNSClient) Preferences(ctx context.Context) (*tailscale.DNSPreferen
 
 // MockDevicesClient implements the DevicesAPI interface for testing
 type MockDevicesClient struct {
-	devices       []tailscale.Device
-	devicesErr    error
-	routes        map[string]*tailscale.DeviceRoutes
-	routesErr     error
+	devices    []tailscale.Device
+	devicesErr error
+	routes     map[string]*tailscale.DeviceRoutes
+	routesErr  error
 }
 
 func (m *MockDevicesClient) List(ctx context.Context) ([]tailscale.Device, error) {

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -72,7 +72,10 @@ func (m *MockDevicesClient) List(ctx context.Context) ([]tailscale.Device, error
 	return m.devices, nil
 }
 
-func (m *MockDevicesClient) SubnetRoutes(ctx context.Context, deviceID string) (*tailscale.DeviceRoutes, error) {
+func (m *MockDevicesClient) SubnetRoutes(
+	ctx context.Context,
+	deviceID string,
+) (*tailscale.DeviceRoutes, error) {
 	if m.routesErr != nil {
 		return nil, m.routesErr
 	}

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -59,8 +59,10 @@ func (m *MockDNSClient) Preferences(ctx context.Context) (*tailscale.DNSPreferen
 
 // MockDevicesClient implements the DevicesAPI interface for testing
 type MockDevicesClient struct {
-	devices    []tailscale.Device
-	devicesErr error
+	devices       []tailscale.Device
+	devicesErr    error
+	routes        map[string]*tailscale.DeviceRoutes
+	routesErr     error
 }
 
 func (m *MockDevicesClient) List(ctx context.Context) ([]tailscale.Device, error) {
@@ -68,6 +70,18 @@ func (m *MockDevicesClient) List(ctx context.Context) ([]tailscale.Device, error
 		return nil, m.devicesErr
 	}
 	return m.devices, nil
+}
+
+func (m *MockDevicesClient) SubnetRoutes(ctx context.Context, deviceID string) (*tailscale.DeviceRoutes, error) {
+	if m.routesErr != nil {
+		return nil, m.routesErr
+	}
+	if m.routes != nil {
+		if routes, ok := m.routes[deviceID]; ok {
+			return routes, nil
+		}
+	}
+	return &tailscale.DeviceRoutes{}, nil
 }
 
 // MockUsersClient implements the UsersAPI interface for testing

--- a/collector/devices.go
+++ b/collector/devices.go
@@ -224,7 +224,14 @@ func (c TailscaleDevicesCollector) Update(
 		// Routes metrics - fetch from separate API endpoint
 		routes, err := client.Devices().SubnetRoutes(ctx, device.ID)
 		if err != nil {
-			c.log.DebugContext(ctx, "Error getting device routes", "device_id", device.ID, "error", err.Error())
+			c.log.DebugContext(
+				ctx,
+				"Error getting device routes",
+				"device_id",
+				device.ID,
+				"error",
+				err.Error(),
+			)
 			// If we can't get routes, emit 0
 			ch <- prometheus.MustNewConstMetric(devicesRoutesAdvertisedDesc, prometheus.GaugeValue, 0,
 				device.ID, device.Name, device.Hostname, device.OS, device.User)

--- a/collector/devices.go
+++ b/collector/devices.go
@@ -222,7 +222,7 @@ func (c TailscaleDevicesCollector) Update(
 		}
 
 		// Routes metrics - fetch from separate API endpoint
-		routes, err := client.DeviceRoutes().Get(ctx, device.ID)
+		routes, err := client.Devices().SubnetRoutes(ctx, device.ID)
 		if err != nil {
 			c.log.DebugContext(ctx, "Error getting device routes", "device_id", device.ID, "error", err.Error())
 			// If we can't get routes, emit 0
@@ -231,9 +231,9 @@ func (c TailscaleDevicesCollector) Update(
 			ch <- prometheus.MustNewConstMetric(devicesRoutesEnabledDesc, prometheus.GaugeValue, 0,
 				device.ID, device.Name, device.Hostname, device.OS, device.User)
 		} else {
-			ch <- prometheus.MustNewConstMetric(devicesRoutesAdvertisedDesc, prometheus.GaugeValue, float64(len(routes.AdvertisedRoutes)),
+			ch <- prometheus.MustNewConstMetric(devicesRoutesAdvertisedDesc, prometheus.GaugeValue, float64(len(routes.Advertised)),
 				device.ID, device.Name, device.Hostname, device.OS, device.User)
-			ch <- prometheus.MustNewConstMetric(devicesRoutesEnabledDesc, prometheus.GaugeValue, float64(len(routes.EnabledRoutes)),
+			ch <- prometheus.MustNewConstMetric(devicesRoutesEnabledDesc, prometheus.GaugeValue, float64(len(routes.Enabled)),
 				device.ID, device.Name, device.Hostname, device.OS, device.User)
 		}
 

--- a/collector/devices.go
+++ b/collector/devices.go
@@ -221,11 +221,21 @@ func (c TailscaleDevicesCollector) Update(
 				device.ID, device.Name, device.Hostname, device.OS, device.User)
 		}
 
-		// Routes metrics
-		ch <- prometheus.MustNewConstMetric(devicesRoutesAdvertisedDesc, prometheus.GaugeValue, float64(len(device.AdvertisedRoutes)),
-			device.ID, device.Name, device.Hostname, device.OS, device.User)
-		ch <- prometheus.MustNewConstMetric(devicesRoutesEnabledDesc, prometheus.GaugeValue, float64(len(device.EnabledRoutes)),
-			device.ID, device.Name, device.Hostname, device.OS, device.User)
+		// Routes metrics - fetch from separate API endpoint
+		routes, err := client.DeviceRoutes().Get(ctx, device.ID)
+		if err != nil {
+			c.log.DebugContext(ctx, "Error getting device routes", "device_id", device.ID, "error", err.Error())
+			// If we can't get routes, emit 0
+			ch <- prometheus.MustNewConstMetric(devicesRoutesAdvertisedDesc, prometheus.GaugeValue, 0,
+				device.ID, device.Name, device.Hostname, device.OS, device.User)
+			ch <- prometheus.MustNewConstMetric(devicesRoutesEnabledDesc, prometheus.GaugeValue, 0,
+				device.ID, device.Name, device.Hostname, device.OS, device.User)
+		} else {
+			ch <- prometheus.MustNewConstMetric(devicesRoutesAdvertisedDesc, prometheus.GaugeValue, float64(len(routes.AdvertisedRoutes)),
+				device.ID, device.Name, device.Hostname, device.OS, device.User)
+			ch <- prometheus.MustNewConstMetric(devicesRoutesEnabledDesc, prometheus.GaugeValue, float64(len(routes.EnabledRoutes)),
+				device.ID, device.Name, device.Hostname, device.OS, device.User)
+		}
 
 		// Latency metrics
 		if device.ClientConnectivity != nil &&

--- a/collector/devices_test.go
+++ b/collector/devices_test.go
@@ -54,14 +54,18 @@ func TestTailscaleDevicesCollector_Update(t *testing.T) {
 							},
 							MachineKey:       "mkey:abcd1234",
 							NodeKey:          "nodekey:efgh5678",
-							AdvertisedRoutes: []string{"192.168.1.0/24"},
-							EnabledRoutes:    []string{"192.168.1.0/24"},
 							ClientConnectivity: &tailscale.ClientConnectivity{
 								DERPLatency: map[string]tailscale.DERPRegion{
 									"nyc": {LatencyMilliseconds: 50},
 									"lax": {LatencyMilliseconds: 100},
 								},
 							},
+						},
+					},
+					routes: map[string]*tailscale.DeviceRoutes{
+						"device-123": {
+							Advertised: []string{"192.168.1.0/24"},
+							Enabled:    []string{"192.168.1.0/24"},
 						},
 					},
 				},

--- a/collector/devices_test.go
+++ b/collector/devices_test.go
@@ -52,8 +52,8 @@ func TestTailscaleDevicesCollector_Update(t *testing.T) {
 							Expires: tailscale.Time{
 								Time: time.Unix(1640995200, 0),
 							},
-							MachineKey:       "mkey:abcd1234",
-							NodeKey:          "nodekey:efgh5678",
+							MachineKey: "mkey:abcd1234",
+							NodeKey:    "nodekey:efgh5678",
 							ClientConnectivity: &tailscale.ClientConnectivity{
 								DERPLatency: map[string]tailscale.DERPRegion{
 									"nyc": {LatencyMilliseconds: 50},


### PR DESCRIPTION
Before changes: 
```
tailscale_devices_routes_advertised{hostname="xxx",id="1561188921434758",name="xxx.X.ts.net",os="linux",tailnet="X.ts.net",user="X"} 0
tailscale_devices_routes_advertised{hostname="xxx",id="8453715359037423",name="xxx.X.ts.net",os="linux",tailnet="X.ts.net",user="X"} 0
```

After changes:
```
tailscale_devices_routes_advertised{hostname="xxx",id="1561188921434758",name="xxx.X.ts.net",os="linux",tailnet="X.ts.net",user="X"} 29
tailscale_devices_routes_advertised{hostname="xxx",id="8453715359037423",name="xxx.X.ts.net",os="linux",tailnet="X.ts.net",user="X"} 29
```
Add device routes metrics using native Tailscale SubnetRoutes API with devices:routes:read OAuth scope
