### PR TITLE
fix(exporter): Use exact scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ The `tailscale-mixin` also has dashboards and alerts for client side `machine` m
 4. Add read access for DNS, Devices, Users, and Keys
 5. Copy the generated token (it's only shown once)
 
+The following exact scopes are required:
+
+```sh
+devices:core:read  
+devices:posture_attributes:read  
+devices:routes:read  
+users:read  
+dns:read  
+auth_keys:read  
+feature_settings:read  
+policy_file:read
+```
+
 ## Installation
 
 ### Binary

--- a/cmd/tailscale-exporter/root.go
+++ b/cmd/tailscale-exporter/root.go
@@ -123,7 +123,8 @@ func runExporter(cmd *cobra.Command, args []string) error {
 		ClientSecret: oauthClientSecret,
 		TokenURL:     "https://api.tailscale.com/api/v2/oauth/token",
 		Scopes: []string{
-			"devices:read",
+			"devices:core:read",
+			"devices:posture_attributes:read",
 			"devices:routes:read",
 			"users:read",
 			"dns:read",


### PR DESCRIPTION
`devices:read` is outdated and fails during startup when using fine grained tokens
