### PR TITLE
feat: Add tailscale_ip and tailscale_ipv6 labels to nodes/devices info metrics

### DIFF
--- a/collector/headscale/nodes.go
+++ b/collector/headscale/nodes.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/adinhodovic/tailscale-exporter/collector/iputil"
 )
 
 const nodesSubsystem = "nodes"
@@ -24,6 +26,8 @@ var (
 			"machine_key",
 			"node_key",
 			"disco_key",
+			"tailscale_ip",
+			"tailscale_ipv6",
 		},
 	)
 	nodesLastSeenDesc = newDesc(
@@ -112,6 +116,8 @@ func (c HeadscaleNodesCollector) Update(
 			userID = formatUint(node.GetUser().GetId())
 		}
 
+		tailscaleIP, tailscaleIPv6 := iputil.SplitIPs(node.GetIpAddresses())
+
 		ch <- prometheus.MustNewConstMetric(nodesInfoDesc, prometheus.GaugeValue, 1,
 			nodeID,
 			node.GetName(),
@@ -122,6 +128,8 @@ func (c HeadscaleNodesCollector) Update(
 			node.GetMachineKey(),
 			node.GetNodeKey(),
 			node.GetDiscoKey(),
+			tailscaleIP,
+			tailscaleIPv6,
 		)
 
 		if ts := node.GetLastSeen(); ts != nil {

--- a/collector/headscale/nodes_test.go
+++ b/collector/headscale/nodes_test.go
@@ -23,6 +23,7 @@ func TestHeadscaleNodesCollector_Update(t *testing.T) {
 		MachineKey:     "mkey:123",
 		NodeKey:        "nodekey:abc",
 		DiscoKey:       "discokey:def",
+		IpAddresses:    []string{"100.64.0.1", "fd7a:115c:a1e0::1"},
 		LastSeen:       timestamppb.New(time.Unix(1_700_000_000, 0)),
 		CreatedAt:      timestamppb.New(time.Unix(1_690_000_000, 0)),
 		Expiry:         timestamppb.New(time.Unix(1_710_000_000, 0)),
@@ -43,7 +44,7 @@ func TestHeadscaleNodesCollector_Update(t *testing.T) {
 	expected := `
 # HELP headscale_nodes_info Node information
 # TYPE headscale_nodes_info gauge
-headscale_nodes_info{disco_key="discokey:def",given_name="server-01",id="1",machine_key="mkey:123",name="node-one",node_key="nodekey:abc",register_method="REGISTER_METHOD_AUTH_KEY",user="alice",user_id="42"} 1
+headscale_nodes_info{disco_key="discokey:def",given_name="server-01",id="1",machine_key="mkey:123",name="node-one",node_key="nodekey:abc",register_method="REGISTER_METHOD_AUTH_KEY",tailscale_ip="100.64.0.1",tailscale_ipv6="fd7a:115c:a1e0::1",user="alice",user_id="42"} 1
 # HELP headscale_nodes_last_seen_timestamp Unix timestamp when node was last seen
 # TYPE headscale_nodes_last_seen_timestamp gauge
 headscale_nodes_last_seen_timestamp{id="1",name="node-one",user="alice"} 1.7e+09

--- a/collector/iputil/iputil.go
+++ b/collector/iputil/iputil.go
@@ -1,0 +1,28 @@
+package iputil
+
+import (
+	"net/netip"
+	"strings"
+)
+
+// SplitIPs separates a mixed list of IP addresses into the first IPv4 and first
+// IPv6 address, returning empty strings for any that are not present. Unparseable
+// entries are skipped. IPv4-in-IPv6 mapped addresses are normalised to IPv4.
+func SplitIPs(ips []string) (ipv4, ipv6 string) {
+	for _, raw := range ips {
+		addr, err := netip.ParseAddr(strings.TrimSpace(raw))
+		if err != nil {
+			continue
+		}
+		addr = addr.Unmap()
+		if addr.Is4() && ipv4 == "" {
+			ipv4 = addr.String()
+		} else if addr.Is6() && ipv6 == "" {
+			ipv6 = addr.String()
+		}
+		if ipv4 != "" && ipv6 != "" {
+			break
+		}
+	}
+	return ipv4, ipv6
+}

--- a/collector/iputil/iputil_test.go
+++ b/collector/iputil/iputil_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 func TestSplitIPs(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    []string
-		wantV4   string
-		wantV6   string
+		name   string
+		input  []string
+		wantV4 string
+		wantV6 string
 	}{
 		{
 			name: "empty",

--- a/collector/iputil/iputil_test.go
+++ b/collector/iputil/iputil_test.go
@@ -1,0 +1,73 @@
+package iputil
+
+import "testing"
+
+func TestSplitIPs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		wantV4   string
+		wantV6   string
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name:   "only ipv4",
+			input:  []string{"100.64.0.1"},
+			wantV4: "100.64.0.1",
+		},
+		{
+			name:   "only ipv6",
+			input:  []string{"fd7a:115c:a1e0::1"},
+			wantV6: "fd7a:115c:a1e0::1",
+		},
+		{
+			name:   "v4 then v6",
+			input:  []string{"100.64.0.1", "fd7a:115c:a1e0::1"},
+			wantV4: "100.64.0.1",
+			wantV6: "fd7a:115c:a1e0::1",
+		},
+		{
+			name:   "v6 then v4",
+			input:  []string{"fd7a:115c:a1e0::1", "100.64.0.1"},
+			wantV4: "100.64.0.1",
+			wantV6: "fd7a:115c:a1e0::1",
+		},
+		{
+			name:   "first of each family wins",
+			input:  []string{"100.64.0.1", "100.64.0.2", "fd7a:115c:a1e0::1", "fd7a:115c:a1e0::2"},
+			wantV4: "100.64.0.1",
+			wantV6: "fd7a:115c:a1e0::1",
+		},
+		{
+			name:   "skips invalid entries",
+			input:  []string{"not-an-ip", "100.64.0.1", "also-bad", "fd7a:115c:a1e0::1"},
+			wantV4: "100.64.0.1",
+			wantV6: "fd7a:115c:a1e0::1",
+		},
+		{
+			name:   "trims whitespace",
+			input:  []string{"  100.64.0.1  ", "\tfd7a:115c:a1e0::1\n"},
+			wantV4: "100.64.0.1",
+			wantV6: "fd7a:115c:a1e0::1",
+		},
+		{
+			name:   "ipv4-mapped ipv6 normalised to ipv4",
+			input:  []string{"::ffff:100.64.0.1"},
+			wantV4: "100.64.0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotV4, gotV6 := SplitIPs(tt.input)
+			if gotV4 != tt.wantV4 {
+				t.Errorf("ipv4: got %q, want %q", gotV4, tt.wantV4)
+			}
+			if gotV6 != tt.wantV6 {
+				t.Errorf("ipv6: got %q, want %q", gotV6, tt.wantV6)
+			}
+		})
+	}
+}

--- a/collector/tailscale/devices.go
+++ b/collector/tailscale/devices.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"tailscale.com/client/tailscale/v2"
+
+	"github.com/adinhodovic/tailscale-exporter/collector/iputil"
 )
 
 const devicesSubsystem = "devices"
@@ -24,6 +26,7 @@ var (
 			"client_version",
 			"user",
 			"tailscale_ip",
+			"tailscale_ipv6",
 			"machine_key",
 			"node_key",
 		},
@@ -158,10 +161,7 @@ func (c TailscaleDevicesCollector) Update(
 
 	// Device metrics
 	for _, device := range devices {
-		tailscaleIP := ""
-		if len(device.Addresses) > 0 {
-			tailscaleIP = device.Addresses[0]
-		}
+		tailscaleIP, tailscaleIPv6 := iputil.SplitIPs(device.Addresses)
 
 		// Normalize client version to semver format
 		normalizedVersion := normalizeVersion(device.ClientVersion)
@@ -169,7 +169,7 @@ func (c TailscaleDevicesCollector) Update(
 		// Device info
 		ch <- prometheus.MustNewConstMetric(deviceesInfoDesc, prometheus.GaugeValue, 1,
 			device.ID, device.Name, device.Hostname, device.OS, normalizedVersion,
-			device.User, tailscaleIP, device.MachineKey, device.NodeKey)
+			device.User, tailscaleIP, tailscaleIPv6, device.MachineKey, device.NodeKey)
 
 		// Device status metrics
 		online := 0.0

--- a/collector/tailscale/devices_test.go
+++ b/collector/tailscale/devices_test.go
@@ -73,7 +73,7 @@ func TestTailscaleDevicesCollector_Update(t *testing.T) {
 			expectedMetrics: `
 # HELP tailscale_devices_info Device information
 # TYPE tailscale_devices_info gauge
-tailscale_devices_info{client_version="1.32.0",hostname="device-one",id="device-123",machine_key="mkey:abcd1234",name="Device One",node_key="nodekey:efgh5678",os="linux",tailscale_ip="100.64.0.1",user="user-456"} 1
+tailscale_devices_info{client_version="1.32.0",hostname="device-one",id="device-123",machine_key="mkey:abcd1234",name="Device One",node_key="nodekey:efgh5678",os="linux",tailscale_ip="100.64.0.1",tailscale_ipv6="fd7a:115c:a1e0:ab12:4843:cd96:6255:6a6a",user="user-456"} 1
 # HELP tailscale_devices_online Whether device is online (last seen within 5 minutes)
 # TYPE tailscale_devices_online gauge
 tailscale_devices_online{hostname="device-one",id="device-123",name="Device One",os="linux",user="user-456"} 0

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -28,7 +28,7 @@ Metrics related to Tailscale devices in the tailnet:
 
 | Metric Name | Type | Description | Labels |
 |-------------|------|-------------|---------|
-| `tailscale_devices_info` | Gauge | Device information | `id`, `name`, `hostname`, `os`, `client_version`, `user`, `tailscale_ip`, `machine_key`, `node_key` |
+| `tailscale_devices_info` | Gauge | Device information | `id`, `name`, `hostname`, `os`, `client_version`, `user`, `tailscale_ip`, `tailscale_ipv6`, `machine_key`, `node_key` |
 | `tailscale_devices_last_seen_timestamp` | Gauge | Unix timestamp when device was last seen | `id`, `name`, `hostname`, `os`, `user` |
 | `tailscale_devices_expires_timestamp` | Gauge | Unix timestamp when device key expires | `id`, `name`, `hostname`, `os`, `user` |
 | `tailscale_devices_created_timestamp` | Gauge | Unix timestamp when device was created | `id`, `name`, `hostname`, `os`, `user` |
@@ -100,7 +100,7 @@ Metrics related to Headscale nodes:
 
 | Metric Name | Type | Description | Labels |
 |-------------|------|-------------|---------|
-| `headscale_nodes_info` | Gauge | Node information | `id`, `name`, `user`, `user_id`, `given_name`, `register_method`, `machine_key`, `node_key`, `disco_key` |
+| `headscale_nodes_info` | Gauge | Node information | `id`, `name`, `user`, `user_id`, `given_name`, `register_method`, `machine_key`, `node_key`, `disco_key`, `tailscale_ip`, `tailscale_ipv6` |
 | `headscale_nodes_last_seen_timestamp` | Gauge | Unix timestamp when node was last seen | `id`, `name`, `user` |
 | `headscale_nodes_created_timestamp` | Gauge | Unix timestamp when node was created | `id`, `name`, `user` |
 | `headscale_nodes_expiry_timestamp` | Gauge | Unix timestamp when node expires | `id`, `name`, `user` |


### PR DESCRIPTION
## Summary

- Add `tailscale_ipv6` label to `tailscale_devices_info`.
- Add `tailscale_ip` and `tailscale_ipv6` labels to `headscale_nodes_info`.
- Introduce a small shared `collector/iputil.SplitIPs` helper that picks the first IPv4 and first IPv6 from a mixed address list (using `net/netip`, with `Unmap()` for IPv4-mapped IPv6).
- Update `docs/METRICS.md` to reflect the new labels.

## Note on behaviour change

The `tailscale_ip` label on `tailscale_devices_info` previously held `device.Addresses[0]` — whichever address came first, IPv4 or IPv6. With this change it always holds the first IPv4 (and `tailscale_ipv6` holds the first IPv6). In practice the Tailscale API returns IPv4 first, but devices whose addresses arrive in v6-first order will see the `tailscale_ip` series identity change. Happy to preserve the old "first address" semantics if you'd prefer a strictly additive change — let me know.

## Test plan

- [x] `go build ./...`
- [x] `go test ./collector/iputil/ ./collector/headscale/ ./collector/tailscale/`
- [x] Table-driven tests cover empty, single-family, both orderings, multiples, invalid entries, whitespace, and IPv4-mapped IPv6.