### PR TITLE
feat: expose Tailscale Services as metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Dashboards and alerts for both are provided in the `tailscale-mixin`.
 - API key management (auth keys)
 - DNS configuration
 - User management
+- Tailscale Service inventory
 - Tailnet settings
 - API health (Tailscale API accessibility)
 
@@ -50,7 +51,7 @@ You can run the exporter to collect metrics from Tailscale (official cloud) and/
 1. Go to the [Tailscale admin console](https://login.tailscale.com/admin/settings/keys)
 2. Navigate to **Settings** → **Oauth Client**
 3. Click on **Create new OAuth client**
-4. Add read access for DNS, Devices, Users, and Keys
+4. Add read access for DNS, Devices, Services, Users, and Keys
 5. Copy the generated token (it's only shown once)
 
 The following exact scopes are required:
@@ -59,6 +60,7 @@ The following exact scopes are required:
 devices:core:read
 devices:posture_attributes:read
 devices:routes:read
+services:read
 users:read
 dns:read
 auth_keys:read
@@ -207,7 +209,7 @@ You can find the full list of metrics in the [METRICS.md](./docs/METRICS.md) fil
 
 ### Client Side Machine Metrics
 
-This project also makes use of the [Tailscale's client side metrics](https://tailscale.com/kb/1482/client-metrics/) that are exposed by Tailscale clients. These metrics provide insights into individual devices connected to your tailnet.
+This project also makes use of the [Tailscale's client side metrics](https://tailscale.com/kb/1482/client-metrics/) that are exposed by Tailscale clients. These metrics provide insights into individual devices connected to your tailnet. Tailscale v1.102 and later expose `tailscaled_serve_inbound_bytes_total` and `tailscaled_serve_outbound_bytes_total` with a `service` label for Tailscale Services. Scrape each device's `/metrics` endpoint to collect them; they are not available through the Tailscale API.
 
 The dashboards and alerts depend on the `tailscale_machine` label to exist, it makes filtering and grouping the metrics easier. Adding the label is fairly straightforward using Prometheus' `relabel_configs`. Here's an example configuration using the `ServiceMonitor` spec:
 

--- a/collector/tailscale/collector.go
+++ b/collector/tailscale/collector.go
@@ -94,6 +94,7 @@ type TailscaleClient interface {
 	Keys() KeysAPI
 	DNS() DNSAPI
 	Devices() DevicesAPI
+	Services() ServicesAPI
 	Users() UsersAPI
 	TailnetSettings() TailnetSettingsAPI
 }
@@ -112,6 +113,11 @@ type DNSAPI interface {
 // DevicesAPI is the subset of *tailscale.DevicesResource you actually use
 type DevicesAPI interface {
 	List(ctx context.Context, opts ...tailscale.ListDevicesOptions) ([]tailscale.Device, error)
+}
+
+// ServicesAPI is the subset of *tailscale.ServicesResource you actually use
+type ServicesAPI interface {
+	List(ctx context.Context) ([]tailscale.Service, error)
 }
 
 // UsersAPI is the subset of *tailscale.UsersResource you actually use
@@ -149,6 +155,10 @@ func (w *TailscaleClientWrapper) DNS() DNSAPI {
 
 func (w *TailscaleClientWrapper) Devices() DevicesAPI {
 	return w.client.Devices()
+}
+
+func (w *TailscaleClientWrapper) Services() ServicesAPI {
+	return w.client.Services()
 }
 
 func (w *TailscaleClientWrapper) Users() UsersAPI {

--- a/collector/tailscale/collector_test.go
+++ b/collector/tailscale/collector_test.go
@@ -63,6 +63,19 @@ type MockDevicesClient struct {
 	devicesErr error
 }
 
+// MockServicesClient implements the ServicesAPI interface for testing
+type MockServicesClient struct {
+	services    []tailscale.Service
+	servicesErr error
+}
+
+func (m *MockServicesClient) List(ctx context.Context) ([]tailscale.Service, error) {
+	if m.servicesErr != nil {
+		return nil, m.servicesErr
+	}
+	return m.services, nil
+}
+
 func (m *MockDevicesClient) List(
 	ctx context.Context,
 	opts ...tailscale.ListDevicesOptions,
@@ -108,6 +121,7 @@ type MockTailscaleClient struct {
 	dnsClient             *MockDNSClient
 	keysClient            *MockKeysClient
 	devicesClient         *MockDevicesClient
+	servicesClient        *MockServicesClient
 	usersClient           *MockUsersClient
 	tailnetSettingsClient *MockTailnetSettingsClient
 }
@@ -122,6 +136,10 @@ func (m *MockTailscaleClient) Keys() KeysAPI {
 
 func (m *MockTailscaleClient) Devices() DevicesAPI {
 	return m.devicesClient
+}
+
+func (m *MockTailscaleClient) Services() ServicesAPI {
+	return m.servicesClient
 }
 
 func (m *MockTailscaleClient) Users() UsersAPI {

--- a/collector/tailscale/services.go
+++ b/collector/tailscale/services.go
@@ -1,0 +1,91 @@
+package tailscale
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const servicesSubsystem = "services"
+
+var (
+	servicesInfoDesc = newDesc(
+		servicesSubsystem,
+		"info",
+		"Tailscale Service information",
+		[]string{"name", "comment", "tags"},
+	)
+	servicesAddressDesc = newDesc(
+		servicesSubsystem,
+		"address",
+		"Whether a Tailscale Service has an advertised address",
+		[]string{"service", "address"},
+	)
+	servicesPortDesc = newDesc(
+		servicesSubsystem,
+		"port",
+		"Whether a Tailscale Service advertises a port",
+		[]string{"service", "port"},
+	)
+)
+
+type TailscaleServicesCollector struct {
+	log *slog.Logger
+}
+
+func init() {
+	registerCollector(servicesSubsystem, NewTailscaleServicesCollector)
+}
+
+func NewTailscaleServicesCollector(config collectorConfig) (Collector, error) {
+	return &TailscaleServicesCollector{log: config.logger}, nil
+}
+
+func (c TailscaleServicesCollector) Update(
+	ctx context.Context,
+	client TailscaleClient,
+	ch chan<- prometheus.Metric,
+) error {
+	c.log.DebugContext(ctx, "Collecting services metrics")
+
+	services, err := client.Services().List(ctx)
+	if err != nil {
+		c.log.ErrorContext(ctx, "Error getting Tailscale services", "error", err.Error())
+		return err
+	}
+
+	for _, service := range services {
+		ch <- prometheus.MustNewConstMetric(
+			servicesInfoDesc,
+			prometheus.GaugeValue,
+			1,
+			service.Name,
+			service.Comment,
+			strings.Join(service.Tags, ","),
+		)
+
+		for _, address := range service.Addrs {
+			ch <- prometheus.MustNewConstMetric(
+				servicesAddressDesc,
+				prometheus.GaugeValue,
+				1,
+				service.Name,
+				address,
+			)
+		}
+
+		for _, port := range service.Ports {
+			ch <- prometheus.MustNewConstMetric(
+				servicesPortDesc,
+				prometheus.GaugeValue,
+				1,
+				service.Name,
+				port,
+			)
+		}
+	}
+
+	return nil
+}

--- a/collector/tailscale/services_test.go
+++ b/collector/tailscale/services_test.go
@@ -1,0 +1,58 @@
+package tailscale
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"tailscale.com/client/tailscale/v2"
+)
+
+func TestTailscaleServicesCollector_Update(t *testing.T) {
+	collector := &TailscaleServicesCollector{log: slog.Default()}
+	ch := make(chan prometheus.Metric, 16)
+
+	err := collector.Update(context.Background(), &MockTailscaleClient{
+		servicesClient: &MockServicesClient{
+			services: []tailscale.Service{
+				{
+					Name:    "svc:web",
+					Comment: "Web service",
+					Tags:    []string{"tag:prod", "tag:web"},
+					Addrs:   []string{"100.100.100.1"},
+					Ports:   []string{"tcp:443", "tcp:80"},
+				},
+			},
+		},
+	}, ch)
+	close(ch)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var metrics []prometheus.Metric
+	for metric := range ch {
+		metrics = append(metrics, metric)
+	}
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(&TestMetricCollector{metrics: metrics})
+	if err := testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP tailscale_services_address Whether a Tailscale Service has an advertised address
+# TYPE tailscale_services_address gauge
+tailscale_services_address{address="100.100.100.1",service="svc:web"} 1
+# HELP tailscale_services_info Tailscale Service information
+# TYPE tailscale_services_info gauge
+tailscale_services_info{comment="Web service",name="svc:web",tags="tag:prod,tag:web"} 1
+# HELP tailscale_services_port Whether a Tailscale Service advertises a port
+# TYPE tailscale_services_port gauge
+tailscale_services_port{port="tcp:443",service="svc:web"} 1
+tailscale_services_port{port="tcp:80",service="svc:web"} 1
+`)); err != nil {
+		t.Errorf("metrics mismatch: %v", err)
+	}
+}

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -81,6 +81,25 @@ Metrics related to Tailnet-wide settings:
 | `tailscale_tailnet_settings_info` | Gauge | Information about the Tailscale Tailnet settings | `acls_externally_managed_on`, `acls_external_link`, `devices_approval_on`, `devices_auto_updates_on`, `users_approval_on`, `users_role_allowed_to_join_external_tailnets`, `network_flow_logging_on`, `regional_routing_on`, `posture_identity_collection_on` |
 | `tailscale_tailnet_settings_devices_key_duration_days` | Gauge | Number of days before device key expiry | None |
 
+### Service Metrics
+
+Metrics related to Tailscale Services in the tailnet:
+
+| Metric Name | Type | Description | Labels |
+|-------------|------|-------------|---------|
+| `tailscale_services_info` | Gauge | Tailscale Service information | `name`, `comment`, `tags` |
+| `tailscale_services_address` | Gauge | Whether a Tailscale Service has an advertised address | `service`, `address` |
+| `tailscale_services_port` | Gauge | Whether a Tailscale Service advertises a port | `service`, `port` |
+
+Tailscale client versions 1.102 and later also expose per-Service throughput metrics directly from each device:
+
+| Metric Name | Type | Description | Labels |
+|-------------|------|-------------|---------|
+| `tailscaled_serve_inbound_bytes_total` | Counter | Bytes received from peers on Serve connections for Tailscale Services | `service` |
+| `tailscaled_serve_outbound_bytes_total` | Counter | Bytes sent to peers on Serve connections for Tailscale Services | `service` |
+
+These client-side metrics must be scraped from each device's `/metrics` endpoint. They do not include device-based Serve, Funnel, or layer 3 Tailscale Services.
+
 ## Headscale Metrics
 
 ### General Metrics


### PR DESCRIPTION
## Summary
- add a Tailscale Services collector backed by the Services API
- expose service info, advertised addresses, and ports as Prometheus metrics
- document the required `services:read` scope and Tailscale v1.102 client-side Serve throughput metrics