### PR TITLE
fix: request Services OAuth scope

### DIFF
--- a/cmd/tailscale-exporter/root.go
+++ b/cmd/tailscale-exporter/root.go
@@ -167,6 +167,7 @@ func runExporter(cmd *cobra.Command, args []string) error {
 				"devices:core:read",
 				"devices:posture_attributes:read",
 				"devices:routes:read",
+				"services:read",
 				"users:read",
 				"dns:read",
 				"auth_keys:read",

--- a/collector/tailscale/services.go
+++ b/collector/tailscale/services.go
@@ -52,7 +52,12 @@ func (c TailscaleServicesCollector) Update(
 
 	services, err := client.Services().List(ctx)
 	if err != nil {
-		c.log.ErrorContext(ctx, "Error getting Tailscale services", "error", err.Error())
+		c.log.ErrorContext(
+			ctx,
+			"Error getting Tailscale services; ensure the OAuth client has services:read",
+			"error",
+			err.Error(),
+		)
 		return err
 	}
 


### PR DESCRIPTION
## Summary
- request `services:read` when obtaining Tailscale OAuth tokens
