### PR TITLE
feat: add Tailscale Service dashboards

### DIFF
--- a/collector/tailscale/services.go
+++ b/collector/tailscale/services.go
@@ -21,13 +21,13 @@ var (
 		servicesSubsystem,
 		"address",
 		"Whether a Tailscale Service has an advertised address",
-		[]string{"service", "address"},
+		[]string{"name", "address"},
 	)
 	servicesPortDesc = newDesc(
 		servicesSubsystem,
 		"port",
 		"Whether a Tailscale Service advertises a port",
-		[]string{"service", "port"},
+		[]string{"name", "port"},
 	)
 )
 

--- a/collector/tailscale/services_test.go
+++ b/collector/tailscale/services_test.go
@@ -44,14 +44,14 @@ func TestTailscaleServicesCollector_Update(t *testing.T) {
 	if err := testutil.GatherAndCompare(reg, strings.NewReader(`
 # HELP tailscale_services_address Whether a Tailscale Service has an advertised address
 # TYPE tailscale_services_address gauge
-tailscale_services_address{address="100.100.100.1",service="svc:web"} 1
+tailscale_services_address{address="100.100.100.1",name="svc:web"} 1
 # HELP tailscale_services_info Tailscale Service information
 # TYPE tailscale_services_info gauge
 tailscale_services_info{comment="Web service",name="svc:web",tags="tag:prod,tag:web"} 1
 # HELP tailscale_services_port Whether a Tailscale Service advertises a port
 # TYPE tailscale_services_port gauge
-tailscale_services_port{port="tcp:443",service="svc:web"} 1
-tailscale_services_port{port="tcp:80",service="svc:web"} 1
+tailscale_services_port{name="svc:web",port="tcp:443"} 1
+tailscale_services_port{name="svc:web",port="tcp:80"} 1
 `)); err != nil {
 		t.Errorf("metrics mismatch: %v", err)
 	}

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -88,8 +88,8 @@ Metrics related to Tailscale Services in the tailnet:
 | Metric Name | Type | Description | Labels |
 |-------------|------|-------------|---------|
 | `tailscale_services_info` | Gauge | Tailscale Service information | `name`, `comment`, `tags` |
-| `tailscale_services_address` | Gauge | Whether a Tailscale Service has an advertised address | `service`, `address` |
-| `tailscale_services_port` | Gauge | Whether a Tailscale Service advertises a port | `service`, `port` |
+| `tailscale_services_address` | Gauge | Whether a Tailscale Service has an advertised address | `name`, `address` |
+| `tailscale_services_port` | Gauge | Whether a Tailscale Service advertises a port | `name`, `port` |
 
 Tailscale client versions 1.102 and later also expose per-Service throughput metrics directly from each device:
 

--- a/tailscale-mixin/dashboards/tailscale-machine.libsonnet
+++ b/tailscale-mixin/dashboards/tailscale-machine.libsonnet
@@ -64,19 +64,38 @@ local tbOverride = tbStandardOptions.override;
           sum(
             rate(
               tailscaled_serve_inbound_bytes_total{
+                %(tailscaled)s
+              }[$__rate_interval]
+            )
+          ) by (exported_service)
+        ||| % defaultFilters,
+        tailscaledServeOutboundBytesByServiceRate: |||
+          sum(
+            rate(
+              tailscaled_serve_outbound_bytes_total{
+                %(tailscaled)s
+              }[$__rate_interval]
+            )
+          ) by (exported_service)
+        ||| % defaultFilters,
+
+        tailscaledServeInboundBytesMachineByServiceRate: |||
+          sum(
+            rate(
+              tailscaled_serve_inbound_bytes_total{
                 %(tailscaledMachine)s
               }[$__rate_interval]
             )
-          ) by (service)
+          ) by (exported_service)
         ||| % defaultFilters,
-        tailscaledServeOutboundBytesByServiceRate: |||
+        tailscaledServeOutboundBytesMachineByServiceRate: |||
           sum(
             rate(
               tailscaled_serve_outbound_bytes_total{
                 %(tailscaledMachine)s
               }[$__rate_interval]
             )
-          ) by (service)
+          ) by (exported_service)
         ||| % defaultFilters,
 
         tailscaledHealthMessagesByType: |||
@@ -493,7 +512,7 @@ local tbOverride = tbStandardOptions.override;
             'Service Inbound Traffic',
             'bps',
             queries.tailscaledServeInboundBytesByServiceRate,
-            '{{ service }}',
+            '{{ exported_service }}',
             description='Inbound traffic handled by Tailscale Services, grouped by service.',
             stack='normal',
           ),
@@ -503,7 +522,7 @@ local tbOverride = tbStandardOptions.override;
             'Service Outbound Traffic',
             'bps',
             queries.tailscaledServeOutboundBytesByServiceRate,
-            '{{ service }}',
+            '{{ exported_service }}',
             description='Outbound traffic handled by Tailscale Services, grouped by service.',
             stack='normal',
           ),
@@ -610,6 +629,26 @@ local tbOverride = tbStandardOptions.override;
             description='Outbound packets by path for the selected machine. Sustained relay packet rate is a useful signal when troubleshooting latency or firewall behavior.',
             stack='normal',
           ),
+
+        tailscaledServeInboundBytesMachineByServiceTimeSeries:
+          mixinUtils.dashboards.timeSeriesPanel(
+            'Service Inbound Traffic by Service',
+            'bps',
+            queries.tailscaledServeInboundBytesMachineByServiceRate,
+            '{{ exported_service }}',
+            description='Inbound traffic handled by Tailscale Services for the selected machine, grouped by service.',
+            stack='normal',
+          ),
+
+        tailscaledServeOutboundBytesMachineByServiceTimeSeries:
+          mixinUtils.dashboards.timeSeriesPanel(
+            'Service Outbound Traffic by Service',
+            'bps',
+            queries.tailscaledServeOutboundBytesMachineByServiceRate,
+            '{{ exported_service }}',
+            description='Outbound traffic handled by Tailscale Services for the selected machine, grouped by service.',
+            stack='normal',
+          ),
       };
 
       local rows =
@@ -658,31 +697,17 @@ local tbOverride = tbStandardOptions.override;
             panels.tailscaledInboundPacketByPathTimeSeries,
             panels.tailscaledOutboundBytesByPathTimeSeries,
             panels.tailscaledOutboundPacketByPathTimeSeries,
+            panels.tailscaledServeInboundBytesByServiceTimeSeries,
+            panels.tailscaledServeOutboundBytesByServiceTimeSeries,
           ],
           panelWidth=12,
           panelHeight=5,
           startY=16,
         ) +
         [
-          row.new('Tailscale Service Traffic') +
-          row.gridPos.withX(0) +
-          row.gridPos.withY(31) +
-          row.gridPos.withW(24) +
-          row.gridPos.withH(1),
-        ] +
-        grid.wrapPanels(
-          [
-            panels.tailscaledServeInboundBytesByServiceTimeSeries,
-            panels.tailscaledServeOutboundBytesByServiceTimeSeries,
-          ],
-          panelWidth=12,
-          panelHeight=5,
-          startY=32,
-        ) +
-        [
           row.new('Tailscale Machine $tailscale_machine') +
           row.gridPos.withX(0) +
-          row.gridPos.withY(38) +
+          row.gridPos.withY(36) +
           row.gridPos.withW(24) +
           row.gridPos.withH(1) +
           row.withRepeat('tailscale_machine'),
@@ -695,7 +720,7 @@ local tbOverride = tbStandardOptions.override;
           ],
           panelWidth=8,
           panelHeight=4,
-          startY=39,
+          startY=37,
         ) +
         grid.wrapPanels(
           [
@@ -705,10 +730,12 @@ local tbOverride = tbStandardOptions.override;
             panels.tailscaledInboundPacketMachineByPathTimeSeries,
             panels.tailscaledOutboundBytesMachineByPathTimeSeries,
             panels.tailscaledOutboundPacketMachineByPathTimeSeries,
+            panels.tailscaledServeInboundBytesMachineByServiceTimeSeries,
+            panels.tailscaledServeOutboundBytesMachineByServiceTimeSeries,
           ],
           panelWidth=12,
           panelHeight=5,
-          startY=43,
+          startY=41,
         );
 
       mixinUtils.dashboards.bypassDashboardValidation +

--- a/tailscale-mixin/dashboards/tailscale-machine.libsonnet
+++ b/tailscale-mixin/dashboards/tailscale-machine.libsonnet
@@ -60,6 +60,25 @@ local tbOverride = tbStandardOptions.override;
         tailscaledOutboundBytesRate: std.strReplace(queries.tailscaledInboundBytesRate, 'inbound', 'outbound'),
         tailscaledOutboundBytesRate1h: std.strReplace(queries.tailscaledOutboundBytesRate, '$__rate_interval', '1h'),
 
+        tailscaledServeInboundBytesByServiceRate: |||
+          sum(
+            rate(
+              tailscaled_serve_inbound_bytes_total{
+                %(tailscaledMachine)s
+              }[$__rate_interval]
+            )
+          ) by (service)
+        ||| % defaultFilters,
+        tailscaledServeOutboundBytesByServiceRate: |||
+          sum(
+            rate(
+              tailscaled_serve_outbound_bytes_total{
+                %(tailscaledMachine)s
+              }[$__rate_interval]
+            )
+          ) by (service)
+        ||| % defaultFilters,
+
         tailscaledHealthMessagesByType: |||
           sum(
             tailscaled_health_messages{
@@ -469,6 +488,26 @@ local tbOverride = tbStandardOptions.override;
             stack='normal',
           ),
 
+        tailscaledServeInboundBytesByServiceTimeSeries:
+          mixinUtils.dashboards.timeSeriesPanel(
+            'Service Inbound Traffic',
+            'bps',
+            queries.tailscaledServeInboundBytesByServiceRate,
+            '{{ service }}',
+            description='Inbound traffic handled by Tailscale Services, grouped by service.',
+            stack='normal',
+          ),
+
+        tailscaledServeOutboundBytesByServiceTimeSeries:
+          mixinUtils.dashboards.timeSeriesPanel(
+            'Service Outbound Traffic',
+            'bps',
+            queries.tailscaledServeOutboundBytesByServiceRate,
+            '{{ service }}',
+            description='Outbound traffic handled by Tailscale Services, grouped by service.',
+            stack='normal',
+          ),
+
         // Tailscale Machine
         tailscaledRoutesMachinePieChartPanel:
           mixinUtils.dashboards.pieChartPanel(
@@ -625,9 +664,25 @@ local tbOverride = tbStandardOptions.override;
           startY=16,
         ) +
         [
-          row.new('Tailscale Machine $tailscale_machine') +
+          row.new('Tailscale Service Traffic') +
           row.gridPos.withX(0) +
           row.gridPos.withY(31) +
+          row.gridPos.withW(24) +
+          row.gridPos.withH(1),
+        ] +
+        grid.wrapPanels(
+          [
+            panels.tailscaledServeInboundBytesByServiceTimeSeries,
+            panels.tailscaledServeOutboundBytesByServiceTimeSeries,
+          ],
+          panelWidth=12,
+          panelHeight=5,
+          startY=32,
+        ) +
+        [
+          row.new('Tailscale Machine $tailscale_machine') +
+          row.gridPos.withX(0) +
+          row.gridPos.withY(38) +
           row.gridPos.withW(24) +
           row.gridPos.withH(1) +
           row.withRepeat('tailscale_machine'),
@@ -640,7 +695,7 @@ local tbOverride = tbStandardOptions.override;
           ],
           panelWidth=8,
           panelHeight=4,
-          startY=32,
+          startY=39,
         ) +
         grid.wrapPanels(
           [
@@ -653,7 +708,7 @@ local tbOverride = tbStandardOptions.override;
           ],
           panelWidth=12,
           panelHeight=5,
-          startY=36,
+          startY=43,
         );
 
       mixinUtils.dashboards.bypassDashboardValidation +

--- a/tailscale-mixin/dashboards/tailscale-overview.libsonnet
+++ b/tailscale-mixin/dashboards/tailscale-overview.libsonnet
@@ -334,21 +334,17 @@ local tbOverride = tbStandardOptions.override;
 
         servicesAddresses: |||
           sum by (name) (
-            label_replace(
-              tailscale_services_address{
-                %(tailnet)s
-              }, "name", "$1", "exported_service", "(.*)"
-            )
+            tailscale_services_address{
+              %(tailnet)s
+            }
           )
         ||| % defaultFilters,
 
         servicesPorts: |||
           sum by (name) (
-            label_replace(
-              tailscale_services_port{
-                %(tailnet)s
-              }, "name", "$1", "exported_service", "(.*)"
-            )
+            tailscale_services_port{
+              %(tailnet)s
+            }
           )
         ||| % defaultFilters,
 

--- a/tailscale-mixin/dashboards/tailscale-overview.libsonnet
+++ b/tailscale-mixin/dashboards/tailscale-overview.libsonnet
@@ -337,7 +337,7 @@ local tbOverride = tbStandardOptions.override;
             label_replace(
               tailscale_services_address{
                 %(tailnet)s
-              }, "name", "$1", "service", "(.*)"
+              }, "name", "$1", "exported_service", "(.*)"
             )
           )
         ||| % defaultFilters,
@@ -347,7 +347,7 @@ local tbOverride = tbStandardOptions.override;
             label_replace(
               tailscale_services_port{
                 %(tailnet)s
-              }, "name", "$1", "service", "(.*)"
+              }, "name", "$1", "exported_service", "(.*)"
             )
           )
         ||| % defaultFilters,
@@ -1183,7 +1183,7 @@ local tbOverride = tbStandardOptions.override;
             panels.servicesInfoTable,
           ],
           panelWidth=24,
-          panelHeight=6,
+          panelHeight=10,
           startY=80,
         );
 

--- a/tailscale-mixin/dashboards/tailscale-overview.libsonnet
+++ b/tailscale-mixin/dashboards/tailscale-overview.libsonnet
@@ -326,6 +326,32 @@ local tbOverride = tbStandardOptions.override;
           ) by (name, id)
         ||| % defaultFilters,
 
+        servicesInfo: |||
+          tailscale_services_info{
+            %(tailnet)s
+          }
+        ||| % defaultFilters,
+
+        servicesAddresses: |||
+          sum by (name) (
+            label_replace(
+              tailscale_services_address{
+                %(tailnet)s
+              }, "name", "$1", "service", "(.*)"
+            )
+          )
+        ||| % defaultFilters,
+
+        servicesPorts: |||
+          sum by (name) (
+            label_replace(
+              tailscale_services_port{
+                %(tailnet)s
+              }, "name", "$1", "service", "(.*)"
+            )
+          )
+        ||| % defaultFilters,
+
         // Keys
         keysInfo: |||
           tailscale_keys_info{
@@ -908,6 +934,56 @@ local tbOverride = tbStandardOptions.override;
             ]
           ),
 
+        servicesInfoTable:
+          mixinUtils.dashboards.tablePanel(
+            'Services',
+            'short',
+            [
+              {
+                expr: queries.servicesInfo,
+              },
+              {
+                expr: queries.servicesAddresses,
+              },
+              {
+                expr: queries.servicesPorts,
+              },
+            ],
+            description='A table showing Tailscale Services and their advertised address and port counts.',
+            sortBy={ name: 'Service', desc: false },
+            transformations=[
+              tbQueryOptions.transformation.withId('merge'),
+              tbQueryOptions.transformation.withId(
+                'organize'
+              ) +
+              tbQueryOptions.transformation.withOptions(
+                {
+                  renameByName: {
+                    name: 'Service',
+                    comment: 'Comment',
+                    tags: 'Tags',
+                    'Value #B': 'Addresses',
+                    'Value #C': 'Ports',
+                  },
+                  indexByName: {
+                    name: 0,
+                    comment: 1,
+                    tags: 2,
+                    'Value #B': 3,
+                    'Value #C': 4,
+                  },
+                  includeByName: {
+                    name: true,
+                    comment: true,
+                    tags: true,
+                    'Value #B': true,
+                    'Value #C': true,
+                  },
+                }
+              ),
+            ],
+          ),
+
         // Keys
         keysInfoTable:
           mixinUtils.dashboards.tablePanel(
@@ -1094,13 +1170,28 @@ local tbOverride = tbStandardOptions.override;
           panelWidth=24,
           panelHeight=10,
           startY=69,
+        ) +
+        [
+          row.new('Services') +
+          row.gridPos.withX(0) +
+          row.gridPos.withY(79) +
+          row.gridPos.withW(24) +
+          row.gridPos.withH(1),
+        ] +
+        grid.wrapPanels(
+          [
+            panels.servicesInfoTable,
+          ],
+          panelWidth=24,
+          panelHeight=6,
+          startY=80,
         );
 
       mixinUtils.dashboards.bypassDashboardValidation +
       dashboard.new(
         'Tailscale / Overview',
       ) +
-      dashboard.withDescription('An overview of Tailscale API metrics including tailnet settings, devices (OS, version, authorization, routes), users (role, status, login state), and auth keys. %s' % mixinUtils.dashboards.dashboardDescriptionLink('tailscale-mixin', 'https://github.com/adinhodovic/tailscale-exporter/tree/main/tailscale-mixin')) +
+      dashboard.withDescription('An overview of Tailscale API metrics including tailnet settings, devices (OS, version, authorization, routes), users (role, status, login state), auth keys, and Services. %s' % mixinUtils.dashboards.dashboardDescriptionLink('tailscale-mixin', 'https://github.com/adinhodovic/tailscale-exporter/tree/main/tailscale-mixin')) +
       dashboard.withUid($._config.dashboardIds[dashboardName]) +
       dashboard.withTags($._config.tags) +
       dashboard.withTimezone('utc') +

--- a/tailscale-mixin/dashboards_out/tailscale-machine.json
+++ b/tailscale-mixin/dashboards_out/tailscale-machine.json
@@ -968,18 +968,6 @@
          "type": "timeseries"
       },
       {
-         "collapsed": false,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 31
-         },
-         "id": 18,
-         "title": "Tailscale Service Traffic",
-         "type": "row"
-      },
-      {
          "datasource": {
             "type": "prometheus",
             "uid": "$datasource"
@@ -1003,9 +991,9 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 31
          },
-         "id": 19,
+         "id": 18,
          "options": {
             "legend": {
                "calcs": [
@@ -1031,8 +1019,8 @@
                   "uid": "$datasource"
                },
                "exemplar": false,
-               "expr": "sum(\n  rate(\n    tailscaled_serve_inbound_bytes_total{\n      cluster=\"$cluster\"\n,\njob=~\"$job\"\n,\ntailscale_machine=~\"$tailscale_machine\"\n\n    }[$__rate_interval]\n  )\n) by (service)\n",
-               "legendFormat": "{{ service }}"
+               "expr": "sum(\n  rate(\n    tailscaled_serve_inbound_bytes_total{\n      cluster=\"$cluster\"\n,\njob=~\"$job\"\n\n    }[$__rate_interval]\n  )\n) by (exported_service)\n",
+               "legendFormat": "{{ exported_service }}"
             }
          ],
          "title": "Service Inbound Traffic",
@@ -1062,9 +1050,9 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 31
          },
-         "id": 20,
+         "id": 19,
          "options": {
             "legend": {
                "calcs": [
@@ -1090,8 +1078,8 @@
                   "uid": "$datasource"
                },
                "exemplar": false,
-               "expr": "sum(\n  rate(\n    tailscaled_serve_outbound_bytes_total{\n      cluster=\"$cluster\"\n,\njob=~\"$job\"\n,\ntailscale_machine=~\"$tailscale_machine\"\n\n    }[$__rate_interval]\n  )\n) by (service)\n",
-               "legendFormat": "{{ service }}"
+               "expr": "sum(\n  rate(\n    tailscaled_serve_outbound_bytes_total{\n      cluster=\"$cluster\"\n,\njob=~\"$job\"\n\n    }[$__rate_interval]\n  )\n) by (exported_service)\n",
+               "legendFormat": "{{ exported_service }}"
             }
          ],
          "title": "Service Outbound Traffic",
@@ -1103,9 +1091,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 38
+            "y": 36
          },
-         "id": 21,
+         "id": 20,
          "repeat": "tailscale_machine",
          "title": "Tailscale Machine $tailscale_machine",
          "type": "row"
@@ -1126,9 +1114,9 @@
             "h": 4,
             "w": 8,
             "x": 0,
-            "y": 39
+            "y": 37
          },
-         "id": 22,
+         "id": 21,
          "options": {
             "displayLabels": [
                "percent"
@@ -1186,9 +1174,9 @@
             "h": 4,
             "w": 8,
             "x": 8,
-            "y": 39
+            "y": 37
          },
-         "id": 23,
+         "id": 22,
          "options": {
             "displayLabels": [
                "percent"
@@ -1246,9 +1234,9 @@
             "h": 4,
             "w": 8,
             "x": 16,
-            "y": 39
+            "y": 37
          },
-         "id": 24,
+         "id": 23,
          "options": {
             "displayLabels": [
                "percent"
@@ -1305,9 +1293,9 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 41
          },
-         "id": 25,
+         "id": 24,
          "options": {
             "legend": {
                "calcs": [
@@ -1364,9 +1352,9 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 41
          },
-         "id": 26,
+         "id": 25,
          "options": {
             "legend": {
                "calcs": [
@@ -1423,9 +1411,9 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 48
+            "y": 46
          },
-         "id": 27,
+         "id": 26,
          "options": {
             "legend": {
                "calcs": [
@@ -1482,9 +1470,9 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 48
+            "y": 46
          },
-         "id": 28,
+         "id": 27,
          "options": {
             "legend": {
                "calcs": [
@@ -1541,9 +1529,9 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 53
+            "y": 51
          },
-         "id": 29,
+         "id": 28,
          "options": {
             "legend": {
                "calcs": [
@@ -1600,9 +1588,9 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 53
+            "y": 51
          },
-         "id": 30,
+         "id": 29,
          "options": {
             "legend": {
                "calcs": [
@@ -1633,6 +1621,124 @@
             }
          ],
          "title": "Outbound Packets by Path",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Inbound traffic handled by Tailscale Services for the selected machine, grouped by service.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "axisSoftMin": 0,
+                  "fillOpacity": 100,
+                  "lineWidth": 1,
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "bps"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 56
+         },
+         "id": 30,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "sum(\n  rate(\n    tailscaled_serve_inbound_bytes_total{\n      cluster=\"$cluster\"\n,\njob=~\"$job\"\n,\ntailscale_machine=~\"$tailscale_machine\"\n\n    }[$__rate_interval]\n  )\n) by (exported_service)\n",
+               "legendFormat": "{{ exported_service }}"
+            }
+         ],
+         "title": "Service Inbound Traffic by Service",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Outbound traffic handled by Tailscale Services for the selected machine, grouped by service.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "axisSoftMin": 0,
+                  "fillOpacity": 100,
+                  "lineWidth": 1,
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "bps"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 56
+         },
+         "id": 31,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "sum(\n  rate(\n    tailscaled_serve_outbound_bytes_total{\n      cluster=\"$cluster\"\n,\njob=~\"$job\"\n,\ntailscale_machine=~\"$tailscale_machine\"\n\n    }[$__rate_interval]\n  )\n) by (exported_service)\n",
+               "legendFormat": "{{ exported_service }}"
+            }
+         ],
+         "title": "Service Outbound Traffic by Service",
          "type": "timeseries"
       }
    ],

--- a/tailscale-mixin/dashboards_out/tailscale-machine.json
+++ b/tailscale-mixin/dashboards_out/tailscale-machine.json
@@ -976,6 +976,136 @@
             "y": 31
          },
          "id": 18,
+         "title": "Tailscale Service Traffic",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Inbound traffic handled by Tailscale Services, grouped by service.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "axisSoftMin": 0,
+                  "fillOpacity": 100,
+                  "lineWidth": 1,
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "bps"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 0,
+            "y": 32
+         },
+         "id": 19,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "sum(\n  rate(\n    tailscaled_serve_inbound_bytes_total{\n      cluster=\"$cluster\"\n,\njob=~\"$job\"\n,\ntailscale_machine=~\"$tailscale_machine\"\n\n    }[$__rate_interval]\n  )\n) by (service)\n",
+               "legendFormat": "{{ service }}"
+            }
+         ],
+         "title": "Service Inbound Traffic",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "Outbound traffic handled by Tailscale Services, grouped by service.",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "axisSoftMin": 0,
+                  "fillOpacity": 100,
+                  "lineWidth": 1,
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "bps"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 5,
+            "w": 12,
+            "x": 12,
+            "y": 32
+         },
+         "id": 20,
+         "options": {
+            "legend": {
+               "calcs": [
+                  "mean",
+                  "max"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true,
+               "sortBy": "Mean",
+               "sortDesc": true
+            },
+            "tooltip": {
+               "mode": "multi",
+               "sort": "desc"
+            }
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "exemplar": false,
+               "expr": "sum(\n  rate(\n    tailscaled_serve_outbound_bytes_total{\n      cluster=\"$cluster\"\n,\njob=~\"$job\"\n,\ntailscale_machine=~\"$tailscale_machine\"\n\n    }[$__rate_interval]\n  )\n) by (service)\n",
+               "legendFormat": "{{ service }}"
+            }
+         ],
+         "title": "Service Outbound Traffic",
+         "type": "timeseries"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 38
+         },
+         "id": 21,
          "repeat": "tailscale_machine",
          "title": "Tailscale Machine $tailscale_machine",
          "type": "row"
@@ -996,9 +1126,9 @@
             "h": 4,
             "w": 8,
             "x": 0,
-            "y": 32
+            "y": 39
          },
-         "id": 19,
+         "id": 22,
          "options": {
             "displayLabels": [
                "percent"
@@ -1056,9 +1186,9 @@
             "h": 4,
             "w": 8,
             "x": 8,
-            "y": 32
+            "y": 39
          },
-         "id": 20,
+         "id": 23,
          "options": {
             "displayLabels": [
                "percent"
@@ -1116,9 +1246,9 @@
             "h": 4,
             "w": 8,
             "x": 16,
-            "y": 32
+            "y": 39
          },
-         "id": 21,
+         "id": 24,
          "options": {
             "displayLabels": [
                "percent"
@@ -1175,9 +1305,9 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 43
          },
-         "id": 22,
+         "id": 25,
          "options": {
             "legend": {
                "calcs": [
@@ -1234,9 +1364,9 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 43
          },
-         "id": 23,
+         "id": 26,
          "options": {
             "legend": {
                "calcs": [
@@ -1293,9 +1423,9 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 48
          },
-         "id": 24,
+         "id": 27,
          "options": {
             "legend": {
                "calcs": [
@@ -1352,9 +1482,9 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 48
          },
-         "id": 25,
+         "id": 28,
          "options": {
             "legend": {
                "calcs": [
@@ -1411,9 +1541,9 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 46
+            "y": 53
          },
-         "id": 26,
+         "id": 29,
          "options": {
             "legend": {
                "calcs": [
@@ -1470,9 +1600,9 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 46
+            "y": 53
          },
-         "id": 27,
+         "id": 30,
          "options": {
             "legend": {
                "calcs": [

--- a/tailscale-mixin/dashboards_out/tailscale-overview.json
+++ b/tailscale-mixin/dashboards_out/tailscale-overview.json
@@ -1888,7 +1888,7 @@
             "overrides": [ ]
          },
          "gridPos": {
-            "h": 6,
+            "h": 10,
             "w": 24,
             "x": 0,
             "y": 80
@@ -1921,7 +1921,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum by (name) (\n  label_replace(\n    tailscale_services_address{\n      cluster=\"$cluster\"\n,\nnamespace=\"$namespace\",\njob=\"$job\",\ntailnet=\"$tailnet\"\n\n    }, \"name\", \"$1\", \"service\", \"(.*)\"\n  )\n)\n",
+               "expr": "sum by (name) (\n  label_replace(\n    tailscale_services_address{\n      cluster=\"$cluster\"\n,\nnamespace=\"$namespace\",\njob=\"$job\",\ntailnet=\"$tailnet\"\n\n    }, \"name\", \"$1\", \"exported_service\", \"(.*)\"\n  )\n)\n",
                "format": "table",
                "instant": true
             },
@@ -1930,7 +1930,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum by (name) (\n  label_replace(\n    tailscale_services_port{\n      cluster=\"$cluster\"\n,\nnamespace=\"$namespace\",\njob=\"$job\",\ntailnet=\"$tailnet\"\n\n    }, \"name\", \"$1\", \"service\", \"(.*)\"\n  )\n)\n",
+               "expr": "sum by (name) (\n  label_replace(\n    tailscale_services_port{\n      cluster=\"$cluster\"\n,\nnamespace=\"$namespace\",\njob=\"$job\",\ntailnet=\"$tailnet\"\n\n    }, \"name\", \"$1\", \"exported_service\", \"(.*)\"\n  )\n)\n",
                "format": "table",
                "instant": true
             }

--- a/tailscale-mixin/dashboards_out/tailscale-overview.json
+++ b/tailscale-mixin/dashboards_out/tailscale-overview.json
@@ -1921,7 +1921,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum by (name) (\n  label_replace(\n    tailscale_services_address{\n      cluster=\"$cluster\"\n,\nnamespace=\"$namespace\",\njob=\"$job\",\ntailnet=\"$tailnet\"\n\n    }, \"name\", \"$1\", \"exported_service\", \"(.*)\"\n  )\n)\n",
+               "expr": "sum by (name) (\n  tailscale_services_address{\n    cluster=\"$cluster\"\n,\nnamespace=\"$namespace\",\njob=\"$job\",\ntailnet=\"$tailnet\"\n\n  }\n)\n",
                "format": "table",
                "instant": true
             },
@@ -1930,7 +1930,7 @@
                   "type": "prometheus",
                   "uid": "$datasource"
                },
-               "expr": "sum by (name) (\n  label_replace(\n    tailscale_services_port{\n      cluster=\"$cluster\"\n,\nnamespace=\"$namespace\",\njob=\"$job\",\ntailnet=\"$tailnet\"\n\n    }, \"name\", \"$1\", \"exported_service\", \"(.*)\"\n  )\n)\n",
+               "expr": "sum by (name) (\n  tailscale_services_port{\n    cluster=\"$cluster\"\n,\nnamespace=\"$namespace\",\njob=\"$job\",\ntailnet=\"$tailnet\"\n\n  }\n)\n",
                "format": "table",
                "instant": true
             }

--- a/tailscale-mixin/dashboards_out/tailscale-overview.json
+++ b/tailscale-mixin/dashboards_out/tailscale-overview.json
@@ -4,7 +4,7 @@
    "annotations": {
       "list": [ ]
    },
-   "description": "An overview of Tailscale API metrics including tailnet settings, devices (OS, version, authorization, routes), users (role, status, login state), and auth keys. The dashboards were generated using [tailscale-mixin](https://github.com/adinhodovic/tailscale-exporter/tree/main/tailscale-mixin). Open issues and create feature requests in the repository.",
+   "description": "An overview of Tailscale API metrics including tailnet settings, devices (OS, version, authorization, routes), users (role, status, login state), auth keys, and Services. The dashboards were generated using [tailscale-mixin](https://github.com/adinhodovic/tailscale-exporter/tree/main/tailscale-mixin). Open issues and create feature requests in the repository.",
    "editable": false,
    "links": [
       {
@@ -1853,6 +1853,116 @@
                      "id": "ID",
                      "key_type": "Key Type",
                      "user_id": "User ID"
+                  }
+               }
+            }
+         ],
+         "type": "table"
+      },
+      {
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 79
+         },
+         "id": 27,
+         "title": "Services",
+         "type": "row"
+      },
+      {
+         "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+         },
+         "description": "A table showing Tailscale Services and their advertised address and port counts.",
+         "fieldConfig": {
+            "defaults": {
+               "links": [ ],
+               "thresholds": {
+                  "steps": [ ]
+               },
+               "unit": "short"
+            },
+            "overrides": [ ]
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 80
+         },
+         "id": 28,
+         "options": {
+            "footer": {
+               "enablePagination": true
+            },
+            "sortBy": [
+               {
+                  "desc": false,
+                  "displayName": "Service"
+               }
+            ]
+         },
+         "pluginVersion": "v11.4.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "tailscale_services_info{\n  cluster=\"$cluster\"\n,\nnamespace=\"$namespace\",\njob=\"$job\",\ntailnet=\"$tailnet\"\n\n}\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum by (name) (\n  label_replace(\n    tailscale_services_address{\n      cluster=\"$cluster\"\n,\nnamespace=\"$namespace\",\njob=\"$job\",\ntailnet=\"$tailnet\"\n\n    }, \"name\", \"$1\", \"service\", \"(.*)\"\n  )\n)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "$datasource"
+               },
+               "expr": "sum by (name) (\n  label_replace(\n    tailscale_services_port{\n      cluster=\"$cluster\"\n,\nnamespace=\"$namespace\",\njob=\"$job\",\ntailnet=\"$tailnet\"\n\n    }, \"name\", \"$1\", \"service\", \"(.*)\"\n  )\n)\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
+         "title": "Services",
+         "transformations": [
+            {
+               "id": "merge"
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "includeByName": {
+                     "Value #B": true,
+                     "Value #C": true,
+                     "comment": true,
+                     "name": true,
+                     "tags": true
+                  },
+                  "indexByName": {
+                     "Value #B": 3,
+                     "Value #C": 4,
+                     "comment": 1,
+                     "name": 0,
+                     "tags": 2
+                  },
+                  "renameByName": {
+                     "Value #B": "Addresses",
+                     "Value #C": "Ports",
+                     "comment": "Comment",
+                     "name": "Service",
+                     "tags": "Tags"
                   }
                }
             }


### PR DESCRIPTION
## Summary
- add a Services row to the Tailscale overview dashboard
- show service comments, tags, advertised address counts, and port counts
- add Service inbound and outbound traffic panels to the tailscaled machine dashboard
- make Service traffic honor the existing `$tailscale_machine` selector
- regenerate dashboard JSON outputs